### PR TITLE
Adding Swift reimplementation of Google flatbuffers benchmark

### DIFF
--- a/FlatBuffersPerformanceTestDesktop/bench.fbs
+++ b/FlatBuffersPerformanceTestDesktop/bench.fbs
@@ -1,0 +1,55 @@
+// Copyright 2015 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+// trying to represent a typical mix of datatypes:
+// 1 array of 3 elements, each element: 1 string, 3 nested objects, 9 scalars
+// root element has the array, additional string and an enum
+
+namespace benchfb;
+
+enum Enum : short { Apples, Pears, Bananas }
+
+// should be struct but not currently supported
+table Foo {
+  id:ulong;
+  count:short;
+  prefix:byte;
+  length:uint;
+}
+
+// should be struct but not currently supported
+table Bar {
+  parent:Foo;
+  time:int;
+  ratio:float;
+  size:ushort;
+}
+
+table FooBar {
+  sibling:Bar;
+  name:string;
+  rating:double;
+  postfix:ubyte;
+}
+
+table FooBarContainer {
+  list:[FooBar];  // 3 copies of the above
+  initialized:bool;
+  fruit:Enum;
+  location:string;
+}
+
+root_type FooBarContainer;
+

--- a/FlatBuffersPerformanceTestDesktop/bench.swift
+++ b/FlatBuffersPerformanceTestDesktop/bench.swift
@@ -1,0 +1,291 @@
+
+// generated with FlatBuffersSchemaEditor https://github.com/mzaks/FlatBuffersSchemaEditor
+
+import FlatBuffersSwift
+
+public enum Enum : Int16 {
+	case Apples, Pears, Bananas
+}
+public final class Foo {
+	public var id : UInt64 = 0
+	public var count : Int16 = 0
+	public var prefix : Int8 = 0
+	public var length : UInt32 = 0
+	public init(){}
+	public init(id: UInt64, count: Int16, prefix: Int8, length: UInt32){
+		self.id = id
+		self.count = count
+		self.prefix = prefix
+		self.length = length
+	}
+}
+public extension Foo {
+	private static func create(reader : FlatBufferReader, objectOffset : Offset?) -> Foo? {
+		guard let objectOffset = objectOffset else {
+			return nil
+		}
+		let _result = Foo()
+		_result.id = reader.get(objectOffset, propertyIndex: 0, defaultValue: 0)
+		_result.count = reader.get(objectOffset, propertyIndex: 1, defaultValue: 0)
+		_result.prefix = reader.get(objectOffset, propertyIndex: 2, defaultValue: 0)
+		_result.length = reader.get(objectOffset, propertyIndex: 3, defaultValue: 0)
+		return _result
+	}
+}
+public extension Foo {
+	public final class LazyAccess{
+		private let _reader : FlatBufferReader!
+		private let _objectOffset : Offset!
+		private init?(reader : FlatBufferReader, objectOffset : Offset?){
+			guard let objectOffset = objectOffset else {
+				_reader = nil
+				_objectOffset = nil
+				return nil
+			}
+			_reader = reader
+			_objectOffset = objectOffset
+		}
+
+		public lazy var id : UInt64 = self._reader.get(self._objectOffset, propertyIndex: 0, defaultValue:0)
+		public lazy var count : Int16 = self._reader.get(self._objectOffset, propertyIndex: 1, defaultValue:0)
+		public lazy var prefix : Int8 = self._reader.get(self._objectOffset, propertyIndex: 2, defaultValue:0)
+		public lazy var length : UInt32 = self._reader.get(self._objectOffset, propertyIndex: 3, defaultValue:0)
+
+		public lazy var createEagerVersion : Foo? = Foo.create(self._reader, objectOffset: self._objectOffset)
+	}
+}
+public extension Foo {
+	private func addToByteArray(builder : FlatBufferBuilder) -> Offset {
+		try! builder.openObject(4)
+		try! builder.addPropertyToOpenObject(3, value : length, defaultValue : 0)
+		try! builder.addPropertyToOpenObject(2, value : prefix, defaultValue : 0)
+		try! builder.addPropertyToOpenObject(1, value : count, defaultValue : 0)
+		try! builder.addPropertyToOpenObject(0, value : id, defaultValue : 0)
+		return try! builder.closeObject()
+	}
+}
+public final class Bar {
+	public var parent : Foo? = nil
+	public var time : Int32 = 0
+	public var ratio : Float32 = 0
+	public var size : UInt16 = 0
+	public init(){}
+	public init(parent: Foo?, time: Int32, ratio: Float32, size: UInt16){
+		self.parent = parent
+		self.time = time
+		self.ratio = ratio
+		self.size = size
+	}
+}
+public extension Bar {
+	private static func create(reader : FlatBufferReader, objectOffset : Offset?) -> Bar? {
+		guard let objectOffset = objectOffset else {
+			return nil
+		}
+		let _result = Bar()
+		_result.parent = Foo.create(reader, objectOffset: reader.getOffset(objectOffset, propertyIndex: 0))
+		_result.time = reader.get(objectOffset, propertyIndex: 1, defaultValue: 0)
+		_result.ratio = reader.get(objectOffset, propertyIndex: 2, defaultValue: 0)
+		_result.size = reader.get(objectOffset, propertyIndex: 3, defaultValue: 0)
+		return _result
+	}
+}
+public extension Bar {
+	public final class LazyAccess{
+		private let _reader : FlatBufferReader!
+		private let _objectOffset : Offset!
+		private init?(reader : FlatBufferReader, objectOffset : Offset?){
+			guard let objectOffset = objectOffset else {
+				_reader = nil
+				_objectOffset = nil
+				return nil
+			}
+			_reader = reader
+			_objectOffset = objectOffset
+		}
+
+		public lazy var parent : Foo.LazyAccess? = Foo.LazyAccess(reader: self._reader, objectOffset : self._reader.getOffset(self._objectOffset, propertyIndex: 0))
+		public lazy var time : Int32 = self._reader.get(self._objectOffset, propertyIndex: 1, defaultValue:0)
+		public lazy var ratio : Float32 = self._reader.get(self._objectOffset, propertyIndex: 2, defaultValue:0)
+		public lazy var size : UInt16 = self._reader.get(self._objectOffset, propertyIndex: 3, defaultValue:0)
+
+		public lazy var createEagerVersion : Bar? = Bar.create(self._reader, objectOffset: self._objectOffset)
+	}
+}
+public extension Bar {
+	private func addToByteArray(builder : FlatBufferBuilder) -> Offset {
+		let offset0 = parent?.addToByteArray(builder) ?? 0
+		try! builder.openObject(4)
+		try! builder.addPropertyToOpenObject(3, value : size, defaultValue : 0)
+		try! builder.addPropertyToOpenObject(2, value : ratio, defaultValue : 0)
+		try! builder.addPropertyToOpenObject(1, value : time, defaultValue : 0)
+		try! builder.addPropertyOffsetToOpenObject(0, offset: offset0)
+		return try! builder.closeObject()
+	}
+}
+public final class FooBar {
+	public var sibling : Bar? = nil
+	public var name : String? = nil
+	public var rating : Float64 = 0
+	public var postfix : UInt8 = 0
+	public init(){}
+	public init(sibling: Bar?, name: String?, rating: Float64, postfix: UInt8){
+		self.sibling = sibling
+		self.name = name
+		self.rating = rating
+		self.postfix = postfix
+	}
+}
+public extension FooBar {
+	private static func create(reader : FlatBufferReader, objectOffset : Offset?) -> FooBar? {
+		guard let objectOffset = objectOffset else {
+			return nil
+		}
+		let _result = FooBar()
+		_result.sibling = Bar.create(reader, objectOffset: reader.getOffset(objectOffset, propertyIndex: 0))
+		_result.name = reader.getString(reader.getOffset(objectOffset, propertyIndex: 1))
+		_result.rating = reader.get(objectOffset, propertyIndex: 2, defaultValue: 0)
+		_result.postfix = reader.get(objectOffset, propertyIndex: 3, defaultValue: 0)
+		return _result
+	}
+}
+public extension FooBar {
+	public final class LazyAccess{
+		private let _reader : FlatBufferReader!
+		private let _objectOffset : Offset!
+		private init?(reader : FlatBufferReader, objectOffset : Offset?){
+			guard let objectOffset = objectOffset else {
+				_reader = nil
+				_objectOffset = nil
+				return nil
+			}
+			_reader = reader
+			_objectOffset = objectOffset
+		}
+
+		public lazy var sibling : Bar.LazyAccess? = Bar.LazyAccess(reader: self._reader, objectOffset : self._reader.getOffset(self._objectOffset, propertyIndex: 0))
+		public lazy var name : String? = self._reader.getString(self._reader.getOffset(self._objectOffset, propertyIndex: 1))
+		public lazy var rating : Float64 = self._reader.get(self._objectOffset, propertyIndex: 2, defaultValue:0)
+		public lazy var postfix : UInt8 = self._reader.get(self._objectOffset, propertyIndex: 3, defaultValue:0)
+
+		public lazy var createEagerVersion : FooBar? = FooBar.create(self._reader, objectOffset: self._objectOffset)
+	}
+}
+public extension FooBar {
+	private func addToByteArray(builder : FlatBufferBuilder) -> Offset {
+		let offset1 = try! builder.createString(name)
+		let offset0 = sibling?.addToByteArray(builder) ?? 0
+		try! builder.openObject(4)
+		try! builder.addPropertyToOpenObject(3, value : postfix, defaultValue : 0)
+		try! builder.addPropertyToOpenObject(2, value : rating, defaultValue : 0)
+		try! builder.addPropertyOffsetToOpenObject(1, offset: offset1)
+		try! builder.addPropertyOffsetToOpenObject(0, offset: offset0)
+		return try! builder.closeObject()
+	}
+}
+public final class FooBarContainer {
+	public var list : [FooBar?] = []
+	public var initialized : Bool = false
+	public var fruit : Enum? = Enum.Apples
+	public var location : String? = nil
+	public init(){}
+	public init(list: [FooBar?], initialized: Bool, fruit: Enum?, location: String?){
+		self.list = list
+		self.initialized = initialized
+		self.fruit = fruit
+		self.location = location
+	}
+}
+public extension FooBarContainer {
+	private static func create(reader : FlatBufferReader, objectOffset : Offset?) -> FooBarContainer? {
+		guard let objectOffset = objectOffset else {
+			return nil
+		}
+		let _result = FooBarContainer()
+		let offset_list : Offset? = reader.getOffset(objectOffset, propertyIndex: 0)
+		let length_list = reader.getVectorLength(offset_list)
+		if(length_list > 0){
+			var index = 0
+			while index < length_list {
+				_result.list.append(FooBar.create(reader, objectOffset: reader.getVectorOffsetElement(offset_list!, index: index)))
+				index += 1
+			}
+		}
+		_result.initialized = reader.get(objectOffset, propertyIndex: 1, defaultValue: false)
+		_result.fruit = Enum(rawValue: reader.get(objectOffset, propertyIndex: 2, defaultValue: Enum.Apples.rawValue))
+		_result.location = reader.getString(reader.getOffset(objectOffset, propertyIndex: 3))
+		return _result
+	}
+}
+public extension FooBarContainer {
+	public static func fromByteArray(data : UnsafePointer<UInt8>) -> FooBarContainer {
+		let reader = FlatBufferReader(bytes: data)
+		let objectOffset = reader.rootObjectOffset
+		return create(reader, objectOffset : objectOffset)!
+	}
+}
+public extension FooBarContainer {
+	public var toByteArray : [UInt8] {
+		let builder = FlatBufferBuilder()
+		return try! builder.finish(addToByteArray(builder), fileIdentifier: nil)
+	}
+}
+public extension FooBarContainer {
+	public final class LazyAccess{
+		private let _reader : FlatBufferReader!
+		private let _objectOffset : Offset!
+		public init(data : UnsafePointer<UInt8>){
+			_reader = FlatBufferReader(bytes: data)
+			_objectOffset = _reader.rootObjectOffset
+		}
+		private init?(reader : FlatBufferReader, objectOffset : Offset?){
+			guard let objectOffset = objectOffset else {
+				_reader = nil
+				_objectOffset = nil
+				return nil
+			}
+			_reader = reader
+			_objectOffset = objectOffset
+		}
+
+		public lazy var list : LazyVector<FooBar.LazyAccess> = {
+			let vectorOffset : Offset? = self._reader.getOffset(self._objectOffset, propertyIndex: 0)
+			let vectorLength = self._reader.getVectorLength(vectorOffset)
+			return LazyVector(count: vectorLength){
+				FooBar.LazyAccess(reader: self._reader, objectOffset : self._reader.getVectorOffsetElement(vectorOffset!, index: $0))
+			}
+		}()
+		public lazy var initialized : Bool = self._reader.get(self._objectOffset, propertyIndex: 1, defaultValue:false)
+		public lazy var fruit : Enum? = Enum(rawValue: self._reader.get(self._objectOffset, propertyIndex: 2, defaultValue:Enum.Apples.rawValue))
+		public lazy var location : String? = self._reader.getString(self._reader.getOffset(self._objectOffset, propertyIndex: 3))
+
+		public lazy var createEagerVersion : FooBarContainer? = FooBarContainer.create(self._reader, objectOffset: self._objectOffset)
+	}
+}
+public extension FooBarContainer {
+	private func addToByteArray(builder : FlatBufferBuilder) -> Offset {
+		let offset3 = try! builder.createString(location)
+		var offset0 = Offset(0)
+		if list.count > 0{
+			var offsets = [Offset?](count: list.count, repeatedValue: nil)
+			var index = list.count - 1
+			while(index >= 0){
+				offsets[index] = list[index]?.addToByteArray(builder)
+				index -= 1
+			}
+			try! builder.startVector(list.count)
+			index = list.count - 1
+			while(index >= 0){
+				try! builder.putOffset(offsets[index])
+				index -= 1
+			}
+			offset0 = builder.endVector()
+		}
+		try! builder.openObject(4)
+		try! builder.addPropertyOffsetToOpenObject(3, offset: offset3)
+		try! builder.addPropertyToOpenObject(2, value : fruit!.rawValue, defaultValue : 0)
+		try! builder.addPropertyToOpenObject(1, value : initialized, defaultValue : false)
+		try! builder.addPropertyOffsetToOpenObject(0, offset: offset0)
+		return try! builder.closeObject()
+	}
+}

--- a/FlatBuffersPerformanceTestDesktop/flatbench.swift
+++ b/FlatBuffersPerformanceTestDesktop/flatbench.swift
@@ -1,0 +1,195 @@
+//
+//  flatbench.swift
+//  FlatBuffersSwift
+//
+//  Created by Joakim Hassila on 2016-04-27.
+//
+//  Reimplementation of parts of the Flatbuffers C++ Benchmark in Swift
+//  to get somewhat comparable performance numbers for both eager and lazy variants
+//  based on the implementation from https://github.com/google/flatbuffers/tree/benchmarks/benchmarks/cpp
+
+import Foundation
+
+let iterations = 1000
+let inner_loop_iterations = 1000
+let bufsize = 10000
+var buf = [UInt8](count: bufsize, repeatedValue: 0)
+
+func flatencode(inout buf:[UInt8], _ bufsize:Int)
+{
+    let veclen = 3
+    var foobars : [FooBar?] = []
+  
+    for i in 0..<veclen { // 0xABADCAFEABADCAFE will overflow in usage
+        let ident : UInt64 = 0xABADCAFE + UInt64(i)
+        let foo = Foo(id: ident, count: 10000 + i, prefix: 64 + i, length: UInt32(1000000 + i))
+        let bar = Bar(parent: foo, time: 123456 + i, ratio: 3.14159 + Float(i), size: UInt16(10000 + i))
+        let name = "Hello, World!"
+        let foobar = FooBar(sibling: bar, name: name, rating: 3.1415432432445543543+Double(i), postfix: UInt8(33 + i))
+        foobars.append(foobar)
+    }
+    
+    let location = "http://google.com/flatbuffers/"
+    let foobarcontainer = FooBarContainer(list: foobars, initialized: true, fruit: Enum.Bananas, location: location)
+    
+    buf = foobarcontainer.toByteArray
+}
+
+func flatdecode(inout buf:[UInt8], _ bufsize:Int) -> FooBarContainer
+{
+    return FooBarContainer.fromByteArray(UnsafePointer(buf))
+}
+
+func flatdecodelazy(inout buf:[UInt8], _ bufsize:Int) -> FooBarContainer.LazyAccess
+{
+    return FooBarContainer.LazyAccess(data: UnsafePointer(buf))
+}
+
+func flatuse(foobarcontainer : FooBarContainer) -> Int
+{
+    var sum:Int = 1
+    sum = sum + Int(foobarcontainer.location!.utf8.count) // characters.count is quite expensive and misleading here
+    sum = sum + Int(foobarcontainer.fruit!.rawValue)
+    
+    for i in 0..<foobarcontainer.list.count {
+        let foobar = foobarcontainer.list[i]!
+        sum = sum + Int(foobar.name!.utf8.count) // characters.count is quite expensive and misleading here
+        sum = sum + Int(foobar.postfix)
+        sum = sum + Int(foobar.rating)
+        
+        let bar = foobar.sibling!
+        
+        sum = sum + Int(bar.ratio)
+        sum = sum + Int(bar.size)
+        sum = sum + Int(bar.time)
+        
+        let foo = bar.parent!
+        sum = sum + Int(foo.count)
+        sum = sum + Int(foo.id)
+        sum = sum + Int(foo.length)
+        sum = sum + Int(foo.prefix)
+    }
+    return sum
+}
+
+// Just a copy-paste as we are lacking a protocol so we could write a generic implementation
+func flatuselazy(foobarcontainer : FooBarContainer.LazyAccess) -> Int
+{
+    var sum:Int = 1
+    sum = sum + Int(foobarcontainer.location!.utf8.count) // characters.count is quite expensive and misleading here
+    sum = sum + Int(foobarcontainer.fruit!.rawValue)
+    
+    for i in 0..<foobarcontainer.list.count {
+        let foobar = foobarcontainer.list[i]!
+        sum = sum + Int(foobar.name!.utf8.count) // characters.count is quite expensive and misleading here
+        sum = sum + Int(foobar.postfix)
+        sum = sum + Int(foobar.rating)
+        
+        let bar = foobar.sibling!
+        
+        sum = sum + Int(bar.ratio)
+        sum = sum + Int(bar.size)
+        sum = sum + Int(bar.time)
+        
+        let foo = bar.parent!
+        sum = sum + Int(foo.count)
+        sum = sum + Int(foo.id)
+        sum = sum + Int(foo.length)
+        sum = sum + Int(foo.prefix)
+    }
+    return sum
+}
+
+// convenience formatter
+extension Double {
+    func string(fractionDigits:Int) -> String {
+        let formatter = NSNumberFormatter()
+        formatter.minimumFractionDigits = fractionDigits
+        formatter.maximumFractionDigits = fractionDigits
+        formatter.minimumIntegerDigits = 1
+        return formatter.stringFromNumber(self) ?? "\(self)"
+    }
+}
+
+func runbench(lazyrun: BooleanType)
+{
+    var encode = 0.0
+    var decode = 0.0
+    var use = 0.0
+    var dealloc = 0.0
+    var total:UInt64 = 0
+    var results : [FooBarContainer] = []
+    var lazyresults : [FooBarContainer.LazyAccess] = []
+    
+    results.reserveCapacity(iterations)
+    lazyresults.reserveCapacity(iterations)
+    
+    for _ in 0..<inner_loop_iterations {
+        
+        let time1 = NSDate()
+        for _ in 0..<iterations {
+            flatencode(&buf, bufsize)
+        }
+        let time2 = NSDate()
+        
+        let time3 = NSDate()
+        for _ in 0..<iterations {
+            if lazyrun {
+                lazyresults.append(flatdecodelazy(&buf, bufsize))
+            }
+            else
+            {
+                results.append(flatdecode(&buf, bufsize))
+            }
+        }
+        let time4 = NSDate()
+        
+        let time5 = NSDate()
+        for index in 0..<iterations {
+            var result = 0
+            if lazyrun {
+                result = flatuselazy(lazyresults[index])
+            }
+            else
+            {
+                result = flatuse(results[index])
+            }
+            assert(result == 8644311666)
+            total = total + UInt64(result)
+        }
+        let time6 = NSDate()
+        
+        let time7 = NSDate()
+        results.removeAll(keepCapacity:true)
+        lazyresults.removeAll(keepCapacity:true)
+        let time8 = NSDate()
+        
+        encode = encode + (time2.timeIntervalSince1970 - time1.timeIntervalSince1970)
+        decode = decode + (time4.timeIntervalSince1970 - time3.timeIntervalSince1970)
+        use = use + (time6.timeIntervalSince1970 - time5.timeIntervalSince1970)
+        dealloc = dealloc + (time8.timeIntervalSince1970 - time7.timeIntervalSince1970)
+    }
+    
+    print("=================================")
+    print("\(((encode) * 1000).string(0)) ms encode")
+    print("\(((decode) * 1000).string(0)) ms decode")
+    print("\(((use) * 1000).string(0)) ms use")
+    print("\(((dealloc) * 1000).string(0)) ms dealloc")
+    print("\(((decode+use+dealloc) * 1000).string(0)) ms decode+use+dealloc")
+    print("=================================")
+    print("Total counter is \(total)") // just to make sure we dont get optimized out
+    print("=================================")
+    print("")
+}
+
+func flatbench() {
+    print("Running a total of \(inner_loop_iterations*iterations) iterations")
+    print("")
+    
+    print("Lazy run")
+    runbench(true)
+    
+    print("Eager run")
+    runbench(false)
+    print("")
+}

--- a/FlatBuffersPerformanceTestDesktop/main.swift
+++ b/FlatBuffersPerformanceTestDesktop/main.swift
@@ -8,8 +8,6 @@
 
 import Foundation
 
-print("-----------------Starting Performance Test-------------")
-
 func testRandomContactListToByteArrayAndBackAgain(){
     let contactList = generateRandomContactList()
     let time1 = NSDate()
@@ -29,10 +27,6 @@ func testRandomContactListToByteArrayAndBackAgain(){
 //    NSData(bytes: UnsafePointer<UInt8>(data), length: data.count).writeToFile("/Users/mzaks/dev/FlatBuffersSwift/Example/contactList.bin", atomically: true)
 }
 
-testRandomContactListToByteArrayAndBackAgain()
-
-print("------------")
-
 func testReadingJSON(){
     let jsonData = NSData(contentsOfFile: "/Users/mzaks/dev/FlatBuffersSwift/Example/contactList_.json")!
     let time1 = NSDate()
@@ -47,4 +41,17 @@ func testReadingJSON(){
 //    newData2.writeToFile("/Users/mzaks/dev/FlatBuffersSwift/Example/contactList_.json", atomically: true)
     
 }
-testReadingJSON()
+
+print("-----------------Starting Performance Tests-------------")
+
+flatbench()
+
+print("------------")
+
+testRandomContactListToByteArrayAndBackAgain()
+
+print("------------")
+
+// testReadingJSON() temporarily commented out as the hardcoded path does not work...
+
+print("------------")

--- a/FlatBuffersSwift.xcodeproj/project.pbxproj
+++ b/FlatBuffersSwift.xcodeproj/project.pbxproj
@@ -22,6 +22,8 @@
 		0BA0E8701C32B6AD00B896B7 /* FlatBuffers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BA0E86C1C32B6AD00B896B7 /* FlatBuffers.swift */; };
 		0BA0E87C1C3AC27800B896B7 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BA0E87B1C3AC27800B896B7 /* main.swift */; };
 		0BBDD0A81C4AAB2A00D955F3 /* FlatBuffersGeneratedAPITest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BBDD0A71C4AAB2A00D955F3 /* FlatBuffersGeneratedAPITest.swift */; };
+		85518AD91CD21D3700EEBCAC /* bench.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85518AD81CD21D3700EEBCAC /* bench.swift */; };
+		85518ADB1CD21D4300EEBCAC /* flatbench.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85518ADA1CD21D4300EEBCAC /* flatbench.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -71,6 +73,9 @@
 		0BA0E8791C3AC27800B896B7 /* FlatBuffersPerformanceTestDesktop */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = FlatBuffersPerformanceTestDesktop; sourceTree = BUILT_PRODUCTS_DIR; };
 		0BA0E87B1C3AC27800B896B7 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		0BBDD0A71C4AAB2A00D955F3 /* FlatBuffersGeneratedAPITest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FlatBuffersGeneratedAPITest.swift; sourceTree = "<group>"; };
+		85518AD71CD21D2B00EEBCAC /* bench.fbs */ = {isa = PBXFileReference; lastKnownFileType = text; path = bench.fbs; sourceTree = "<group>"; };
+		85518AD81CD21D3700EEBCAC /* bench.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = bench.swift; sourceTree = "<group>"; };
+		85518ADA1CD21D4300EEBCAC /* flatbench.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = flatbench.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -158,7 +163,10 @@
 		0BA0E87A1C3AC27800B896B7 /* FlatBuffersPerformanceTestDesktop */ = {
 			isa = PBXGroup;
 			children = (
+				85518AD71CD21D2B00EEBCAC /* bench.fbs */,
 				0BA0E87B1C3AC27800B896B7 /* main.swift */,
+				85518ADA1CD21D4300EEBCAC /* flatbench.swift */,
+				85518AD81CD21D3700EEBCAC /* bench.swift */,
 			);
 			path = FlatBuffersPerformanceTestDesktop;
 			sourceTree = "<group>";
@@ -316,8 +324,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				85518ADB1CD21D4300EEBCAC /* flatbench.swift in Sources */,
 				0B62C2081C49391F002500FE /* contactList.swift in Sources */,
 				0BA0E87C1C3AC27800B896B7 /* main.swift in Sources */,
+				85518AD91CD21D3700EEBCAC /* bench.swift in Sources */,
 				0B62C20C1C4958DA002500FE /* contactListGenerator.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/FlatBuffersSwift.xcodeproj/xcshareddata/xcschemes/FlatBuffersPerformanceTestDesktopOptimized.xcscheme
+++ b/FlatBuffersSwift.xcodeproj/xcshareddata/xcschemes/FlatBuffersPerformanceTestDesktopOptimized.xcscheme
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0730"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "0BA0E8781C3AC27800B896B7"
+               BuildableName = "FlatBuffersPerformanceTestDesktop"
+               BlueprintName = "FlatBuffersPerformanceTestDesktop"
+               ReferencedContainer = "container:FlatBuffersSwift.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "0BA0E8781C3AC27800B896B7"
+            BuildableName = "FlatBuffersPerformanceTestDesktop"
+            BlueprintName = "FlatBuffersPerformanceTestDesktop"
+            ReferencedContainer = "container:FlatBuffersSwift.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Release"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "0BA0E8781C3AC27800B896B7"
+            BuildableName = "FlatBuffersPerformanceTestDesktop"
+            BlueprintName = "FlatBuffersPerformanceTestDesktop"
+            ReferencedContainer = "container:FlatBuffersSwift.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "0BA0E8781C3AC27800B896B7"
+            BuildableName = "FlatBuffersPerformanceTestDesktop"
+            BlueprintName = "FlatBuffersPerformanceTestDesktop"
+            ReferencedContainer = "container:FlatBuffersSwift.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/FlatBuffersSwift/LazyVector.swift
+++ b/FlatBuffersSwift/LazyVector.swift
@@ -34,7 +34,7 @@ public final class LazyVector<T> : SequenceType {
     public func generate() -> AnyGenerator<T> {
         var index = 0
         
-        return anyGenerator({
+        return AnyGenerator(body: {
             let value = self[index]
             index += 1
             return value


### PR DESCRIPTION
First stab at Swift implementation of the flat buffers test from https://github.com/google/flatbuffers/tree/benchmarks/benchmarks/cpp) with some caveats (using tables instead of structs as it is unsupported, ...).

Can be used both for getting comparative numbers, but also for performance improvements.
