### PR TITLE
Fix memory leaks in FlatBufferBuilder

### DIFF
--- a/FlatBuffersSwift/FlatBufferBuilder.swift
+++ b/FlatBuffersSwift/FlatBufferBuilder.swift
@@ -221,8 +221,8 @@ public class FlatBufferBuilder {
             return 0
         }
 
-        let buf = value.cStringUsingEncoding(NSUTF8StringEncoding)!
-        let length = buf.count - 1
+        let buf = Array(value.utf8)
+        let length = buf.count
         
         increaseCapacity(length)
         _data.advancedBy(leftCursor-length).initializeFrom(UnsafeMutablePointer<UInt8>(buf), count: length)

--- a/FlatBuffersSwift/FlatBufferBuilder.swift
+++ b/FlatBuffersSwift/FlatBufferBuilder.swift
@@ -37,6 +37,10 @@ public class FlatBufferBuilder {
         _data = UnsafeMutablePointer.alloc(capacity)
     }
     
+    deinit {
+        _data.dealloc(capacity)
+    }    
+
     private func increaseCapacity(size : Int){
         guard leftCursor <= size else {
             return


### PR DESCRIPTION
Added missing deinit to reclaim allocated memory by builder.
