### PR TITLE
Pooling of readers

### DIFF
--- a/FlatBuffersSwift/FlatBufferBuilder.swift
+++ b/FlatBuffersSwift/FlatBufferBuilder.swift
@@ -19,6 +19,7 @@ public enum FlatBufferBuilderError : ErrorType {
 
 public final class FlatBufferBuilder {
     
+    public static var maxInstanceCacheSize : UInt = 1000 // max number of cached instances
     static var builderPool : [FlatBufferBuilder] = []
     
     public var cache : [ObjectIdentifier : Offset] = [:]
@@ -397,7 +398,7 @@ public extension FlatBufferBuilder {
     }
     
     public static func reuse(builder : FlatBufferBuilder) {
-        if (builderPool.count < 100) // max pool size
+        if (UInt(builderPool.count) < maxInstanceCacheSize) 
         {
             builder.reset()
             builderPool.append(builder)

--- a/FlatBuffersSwift/FlatBufferReader.swift
+++ b/FlatBuffersSwift/FlatBufferReader.swift
@@ -13,6 +13,7 @@ public enum FlatBufferReaderError : ErrorType {
 
 public final class FlatBufferReader {
 
+    public static var maxInstanceCacheSize : UInt = 1000 // max number of cached instances
     static var instancePool : [FlatBufferReader] = []
     
     public var config : BinaryReadConfig
@@ -208,7 +209,7 @@ public extension FlatBufferReader {
     }
     
     public static func reuse(reader : FlatBufferReader) {
-        if (instancePool.count < 100) // max pool size
+        if (UInt(instancePool.count) < maxInstanceCacheSize)
         {
             reader.reset()
             instancePool.append(reader)


### PR DESCRIPTION
Added analogous pooling of readers, gives ~30% decode boost on the eager flatbuffers test.

Codegen needs to be adopted in a similar way in two places:

```
public extension FooBarContainer {
    public static func fromByteArray(data : UnsafePointer<UInt8>, config : BinaryReadConfig = BinaryReadConfig()) -> FooBarContainer {
--->        let reader = FlatBufferReader.create(data, config: config)
        let objectOffset = reader.rootObjectOffset
--->        let result = create(reader, objectOffset : objectOffset)!
--->        FlatBufferReader.reuse(reader)
--->        return result
    }
}

```

and

```
public extension FooBarContainer {
    public final class LazyAccess : Hashable {
        private let _reader : FlatBufferReader!
        private let _objectOffset : Offset!
        public init(data : UnsafePointer<UInt8>, config : BinaryReadConfig = BinaryReadConfig()){
--->            _reader = FlatBufferReader.create(data, config: config)
            _objectOffset = _reader.rootObjectOffset
        }

--->        deinit
--->        {
--->            FlatBufferReader.reuse(_reader)
--->        }

```
