### PR TITLE
Allow explicit use of builders and access to raw data buffers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: objective-c
 osx_image: xcode7.3
 script:
-  - echo -en "travis_fold:start:generate\r"
-  - sh generate.sh
-  - echo -en "travis_fold:end:generate\r"
+#  - echo -en "travis_fold:start:generate\r"
+#  - sh generate.sh
+#  - echo -en "travis_fold:end:generate\r"
   - echo -en "travis_fold:start:unit_test\r"
   - xcodebuild test -project FlatBuffersSwift.xcodeproj -scheme FlatBuffersSwift ONLY_ACTIVE_ARCH=NO
   - echo -en "travis_fold:end:unit_test\r"

--- a/Example/contactList.swift
+++ b/Example/contactList.swift
@@ -52,11 +52,22 @@ public extension ContactList {
 		let builder = FlatBufferBuilder.create(config)
 		let offset = addToByteArray(builder)
 		performLateBindings(builder)
-		let result = try! builder.finish(offset, fileIdentifier: nil)
+		try! builder.finish(offset, fileIdentifier: nil)
+		let result = builder.data
 		FlatBufferBuilder.reuse(builder)
 		return result
 	}
 }
+
+public extension ContactList {
+    public func toFlatBufferBuilder (builder : FlatBufferBuilder) -> Void {
+        let offset = addToByteArray(builder)
+        performLateBindings(builder)
+        try! builder.finish(offset, fileIdentifier: nil)
+        return
+    }
+}
+
 public extension ContactList {
 	public final class LazyAccess : Hashable {
 		private let _reader : FlatBufferReader!
@@ -1603,7 +1614,7 @@ public final class FlatBufferBuilder {
         return Offset(cursor)
     }
     
-    public func finish(offset : Offset, fileIdentifier : String?) throws -> [UInt8] {
+    public func finish(offset : Offset, fileIdentifier : String?) throws -> Void {
         guard offset <= Int32(cursor) else {
             throw FlatBufferBuilderError.OffsetIsTooBig
         }
@@ -1627,8 +1638,7 @@ public final class FlatBufferBuilder {
         withUnsafePointer(&v){
             _data.advancedBy(leftCursor - prefixLength).assignFrom(UnsafeMutablePointer<UInt8>($0), count: c)
         }
-        
-        return Array(UnsafeBufferPointer(start: UnsafePointer<UInt8>(_data).advancedBy(leftCursor - prefixLength), count: cursor+prefixLength))
+        cursor += prefixLength
     }
 }
 
@@ -1665,7 +1675,7 @@ public extension FlatBufferBuilder {
     }
     
     public static func reuse(builder : FlatBufferBuilder) {
-        if (UInt(builderPool.count) < maxInstanceCacheSize) 
+        if (UInt(builderPool.count) < maxInstanceCacheSize)
         {
             builder.reset()
             builderPool.append(builder)

--- a/Example/contactList.swift
+++ b/Example/contactList.swift
@@ -1308,6 +1308,8 @@ public final class FlatBufferBuilder {
     
     var capacity : Int
     private var _data : UnsafeMutablePointer<UInt8>
+    var _dataCount : Int { return cursor } // count of bytes in unsafe buffer
+    var _dataStart : UnsafeMutablePointer<UInt8> { return _data.advancedBy(leftCursor) } // start of actual raw unsafe buffer data
     var data : [UInt8] {
         return Array(UnsafeBufferPointer(start: UnsafePointer<UInt8>(_data).advancedBy(leftCursor), count: cursor))
     }

--- a/FlatBuffersPerformanceTestDesktop/bench.swift
+++ b/FlatBuffersPerformanceTestDesktop/bench.swift
@@ -178,10 +178,20 @@ public extension FooBarContainer {
 		let builder = FlatBufferBuilder.create(config)
 		let offset = addToByteArray(builder)
 		performLateBindings(builder)
-		let result = try! builder.finish(offset, fileIdentifier: nil)
+		try! builder.finish(offset, fileIdentifier: nil)
+		let result = builder.data
 		FlatBufferBuilder.reuse(builder)
 		return result
 	}
+}
+
+public extension FooBarContainer {
+    public func toFlatBufferBuilder (builder : FlatBufferBuilder) -> Void {
+        let offset = addToByteArray(builder)
+        performLateBindings(builder)
+        try! builder.finish(offset, fileIdentifier: nil)
+        return
+    }
 }
 public extension FooBarContainer {
 	public final class LazyAccess : Hashable {

--- a/FlatBuffersSwift.xcodeproj/project.pbxproj
+++ b/FlatBuffersSwift.xcodeproj/project.pbxproj
@@ -78,6 +78,8 @@
 		85518AD71CD21D2B00EEBCAC /* bench.fbs */ = {isa = PBXFileReference; lastKnownFileType = text; path = bench.fbs; sourceTree = "<group>"; };
 		85518AD81CD21D3700EEBCAC /* bench.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = bench.swift; sourceTree = "<group>"; };
 		85518ADA1CD21D4300EEBCAC /* flatbench.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = flatbench.swift; sourceTree = "<group>"; };
+		85EE88611CDE83E00030231F /* generate.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = generate.sh; sourceTree = SOURCE_ROOT; };
+		85EE88621CDE84640030231F /* .travis.yml */ = {isa = PBXFileReference; lastKnownFileType = text; name = .travis.yml; path = ../.travis.yml; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -123,6 +125,7 @@
 				0BA0E8471C32B62200B896B7 /* FlatBuffersSwift */,
 				0BA0E8531C32B62200B896B7 /* FlatBuffersSwiftTests */,
 				0BA0E87A1C3AC27800B896B7 /* FlatBuffersPerformanceTestDesktop */,
+				85EE885C1CDE830A0030231F /* Resources */,
 				0BA0E8461C32B62200B896B7 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -172,6 +175,16 @@
 				85518AD81CD21D3700EEBCAC /* bench.swift */,
 			);
 			path = FlatBuffersPerformanceTestDesktop;
+			sourceTree = "<group>";
+		};
+		85EE885C1CDE830A0030231F /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				85EE88611CDE83E00030231F /* generate.sh */,
+				85EE88621CDE84640030231F /* .travis.yml */,
+			);
+			name = Resources;
+			path = Example;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */

--- a/FlatBuffersSwift/FlatBufferBuilder.swift
+++ b/FlatBuffersSwift/FlatBufferBuilder.swift
@@ -30,6 +30,8 @@ public final class FlatBufferBuilder {
     
     var capacity : Int
     private var _data : UnsafeMutablePointer<UInt8>
+    var _dataCount : Int { return cursor } // count of bytes in unsafe buffer
+    var _dataStart : UnsafeMutablePointer<UInt8> { return _data.advancedBy(leftCursor) } // start of actual raw unsafe buffer data
     var data : [UInt8] {
         return Array(UnsafeBufferPointer(start: UnsafePointer<UInt8>(_data).advancedBy(leftCursor), count: cursor))
     }
@@ -336,7 +338,7 @@ public final class FlatBufferBuilder {
         return Offset(cursor)
     }
     
-    public func finish(offset : Offset, fileIdentifier : String?) throws -> [UInt8] {
+    public func finish(offset : Offset, fileIdentifier : String?) throws -> Void {
         guard offset <= Int32(cursor) else {
             throw FlatBufferBuilderError.OffsetIsTooBig
         }
@@ -360,8 +362,7 @@ public final class FlatBufferBuilder {
         withUnsafePointer(&v){
             _data.advancedBy(leftCursor - prefixLength).assignFrom(UnsafeMutablePointer<UInt8>($0), count: c)
         }
-        
-        return Array(UnsafeBufferPointer(start: UnsafePointer<UInt8>(_data).advancedBy(leftCursor - prefixLength), count: cursor+prefixLength))
+        cursor += prefixLength
     }
 }
 

--- a/FlatBuffersSwift/FlatBufferBuilder.swift
+++ b/FlatBuffersSwift/FlatBufferBuilder.swift
@@ -30,9 +30,9 @@ public final class FlatBufferBuilder {
     
     var capacity : Int
     private var _data : UnsafeMutablePointer<UInt8>
-    var _dataCount : Int { return cursor } // count of bytes in unsafe buffer
-    var _dataStart : UnsafeMutablePointer<UInt8> { return _data.advancedBy(leftCursor) } // start of actual raw unsafe buffer data
-    var data : [UInt8] {
+    public var _dataCount : Int { return cursor } // count of bytes in unsafe buffer
+    public var _dataStart : UnsafeMutablePointer<UInt8> { return _data.advancedBy(leftCursor) } // start of actual raw unsafe buffer data
+    public var data : [UInt8] {
         return Array(UnsafeBufferPointer(start: UnsafePointer<UInt8>(_data).advancedBy(leftCursor), count: cursor))
     }
     var cursor = 0

--- a/FlatBuffersSwiftTests/FlatBuffersTests.swift
+++ b/FlatBuffersSwiftTests/FlatBuffersTests.swift
@@ -297,7 +297,8 @@ class FlatBuffersTests: XCTestCase {
         try! fbb.addPropertyToOpenObject(0, value: true, defaultValue: false)
         try! fbb.addPropertyOffsetToOpenObject(1, offset: sOffset)
         let oOffset = try! fbb.closeObject()
-        let data = try! fbb.finish(oOffset, fileIdentifier: "test")
+        try! fbb.finish(oOffset, fileIdentifier: "test")
+        let data = fbb.data
         
         XCTAssertEqual(data,
             [
@@ -323,7 +324,8 @@ class FlatBuffersTests: XCTestCase {
         try! fbb.addPropertyToOpenObject(0, value: true, defaultValue: false)
         try! fbb.addPropertyOffsetToOpenObject(1, offset: sOffset)
         let oOffset = try! fbb.closeObject()
-        let data = try! fbb.finish(oOffset, fileIdentifier: nil)
+        try! fbb.finish(oOffset, fileIdentifier: nil)
+        let data = fbb.data
         
         XCTAssertEqual(data,
             [
@@ -348,7 +350,8 @@ class FlatBuffersTests: XCTestCase {
         try! fbb.addPropertyToOpenObject(0, value: true, defaultValue: false)
         try! fbb.addPropertyOffsetToOpenObject(1, offset: sOffset)
         let oOffset = try! fbb.closeObject()
-        let data = try! fbb.finish(oOffset, fileIdentifier: nil)
+        try! fbb.finish(oOffset, fileIdentifier: nil)
+        let data = fbb.data
         
         XCTAssertEqual(data,
             [
@@ -377,7 +380,8 @@ class FlatBuffersTests: XCTestCase {
         try! fbb.addPropertyToOpenObject(0, value: true, defaultValue: false)
         try! fbb.addPropertyOffsetToOpenObject(1, offset: sOffset)
         let oOffset = try! fbb.closeObject()
-        let data = try! fbb.finish(oOffset, fileIdentifier: nil)
+        try! fbb.finish(oOffset, fileIdentifier: nil)
+        let data = fbb.data
         
         XCTAssertEqual(data,
             [
@@ -408,8 +412,9 @@ class FlatBuffersTests: XCTestCase {
         try! fbb.addPropertyToOpenObject(2, value: true, defaultValue: false)
         try! fbb.addPropertyOffsetToOpenObject(1, offset: sOffset)
         let oOffset = try! fbb.closeObject()
-        let data = try! fbb.finish(oOffset, fileIdentifier: nil)
-        
+        try! fbb.finish(oOffset, fileIdentifier: nil)
+        let data = fbb.data
+
         XCTAssertEqual(data,
             [
                 14,  0,  0,  0,      // root object offset
@@ -441,8 +446,9 @@ class FlatBuffersTests: XCTestCase {
         try! fbb.addPropertyToOpenObject(0, value: true, defaultValue: false)
         try! fbb.addPropertyOffsetToOpenObject(1, offset: sOffset)
         let oOffset = try! fbb.closeObject()
-        let data = try! fbb.finish(oOffset, fileIdentifier: nil)
-        
+        try! fbb.finish(oOffset, fileIdentifier: nil)
+        let data = fbb.data
+
         XCTAssertEqual(data,
             [
                 14,  0,  0,  0,      // root object offset
@@ -478,8 +484,9 @@ class FlatBuffersTests: XCTestCase {
         try! fbb.addPropertyOffsetToOpenObject(1, offset: oOffset1)
         let oOffset2 = try! fbb.closeObject()
         
-        let data = try! fbb.finish(oOffset2, fileIdentifier: nil)
-        
+        try! fbb.finish(oOffset2, fileIdentifier: nil)
+        let data = fbb.data
+
         let reader = FlatBufferReader(buffer: data, config: BinaryReadConfig())
         let objectOffset = reader.rootObjectOffset
         let objectOffset2 : Offset = reader.getOffset(objectOffset, propertyIndex: 1)!
@@ -500,8 +507,9 @@ class FlatBuffersTests: XCTestCase {
         try! fbb.addPropertyOffsetToOpenObject(1, offset: sOffset)
         let oOffset1 = try! fbb.closeObject()
         
-        let data = try! fbb.finish(oOffset1, fileIdentifier: nil)
-        
+        try! fbb.finish(oOffset1, fileIdentifier: nil)
+        let data = fbb.data
+
         let reader = FlatBufferReader(buffer: data, config: BinaryReadConfig())
         let objectOffset = reader.rootObjectOffset
         let objectOffset2 : Offset = reader.getOffset(objectOffset, propertyIndex: 1)!
@@ -523,8 +531,9 @@ class FlatBuffersTests: XCTestCase {
         try! fbb.addPropertyOffsetToOpenObject(1, offset: vOffset)
         let oOffset1 = try! fbb.closeObject()
         
-        let data = try! fbb.finish(oOffset1, fileIdentifier: nil)
-        
+        try! fbb.finish(oOffset1, fileIdentifier: nil)
+        let data = fbb.data
+
         let reader = FlatBufferReader(buffer: data, config: BinaryReadConfig())
         let objectOffset = reader.rootObjectOffset
         let objectOffset2 : Offset = reader.getOffset(objectOffset, propertyIndex: 1)!
@@ -543,8 +552,9 @@ class FlatBuffersTests: XCTestCase {
         let vOffset = fbb.endVector()
         
         try! fbb.replaceOffset(sOffset, atCursor: cursor)
-        let data = try! fbb.finish(vOffset, fileIdentifier: nil)
-        
+        try! fbb.finish(vOffset, fileIdentifier: nil)
+        let data = fbb.data
+
         let reader = FlatBufferReader(buffer: data, config: BinaryReadConfig())
         let objectOffset = reader.rootObjectOffset
         let length = reader.getVectorLength(objectOffset)
@@ -562,8 +572,9 @@ class FlatBuffersTests: XCTestCase {
         let oOffset = try! fbb.closeObject()
         
         try! fbb.replaceOffset(sOffset, atCursor: cursor)
-        let data = try! fbb.finish(oOffset, fileIdentifier: nil)
-        
+        try! fbb.finish(oOffset, fileIdentifier: nil)
+        let data = fbb.data
+
         let reader = FlatBufferReader(buffer: data, config: BinaryReadConfig())
         let objectOffset = reader.rootObjectOffset
         let objectOffset3 : Offset? = reader.getOffset(objectOffset, propertyIndex: 0)
@@ -578,8 +589,9 @@ class FlatBuffersTests: XCTestCase {
         try! fbb.addPropertyToOpenObject(0, value: 2.5, defaultValue: 0)
         let oOffset = try! fbb.closeObject()
         
-        let data = try! fbb.finish(oOffset, fileIdentifier: nil)
-        
+        try! fbb.finish(oOffset, fileIdentifier: nil)
+        let data = fbb.data
+
         let reader = FlatBufferReader(buffer: data, config: BinaryReadConfig())
         let objectOffset = reader.rootObjectOffset
         var v1 : Double = reader.get(objectOffset, propertyIndex: 0)!
@@ -609,8 +621,9 @@ class FlatBuffersTests: XCTestCase {
         try! fbb.addPropertyOffsetToOpenObject(0, offset: offset)
         let oOffset = try! fbb.closeObject()
         
-        let data = try! fbb.finish(oOffset, fileIdentifier: nil)
-        
+        try! fbb.finish(oOffset, fileIdentifier: nil)
+        let data = fbb.data
+
         let reader = FlatBufferReader(buffer: data, config: BinaryReadConfig())
         let objectOffset = reader.rootObjectOffset
         let v_o = reader.getOffset(objectOffset, propertyIndex: 0)!

--- a/FlatBuffersSwiftTests/contactList.swift
+++ b/FlatBuffersSwiftTests/contactList.swift
@@ -53,10 +53,20 @@ public extension ContactList {
 		let builder = FlatBufferBuilder.create(config)
 		let offset = addToByteArray(builder)
 		performLateBindings(builder)
-		let result = try! builder.finish(offset, fileIdentifier: nil)
+		try! builder.finish(offset, fileIdentifier: nil)
+		let result = builder.data
 		FlatBufferBuilder.reuse(builder)
 		return result
 	}
+}
+
+public extension ContactList {
+    public func toFlatBufferBuilder (builder : FlatBufferBuilder) -> Void {
+        let offset = addToByteArray(builder)
+        performLateBindings(builder)
+        try! builder.finish(offset, fileIdentifier: nil)
+        return
+    }
 }
 public extension ContactList {
 	public final class LazyAccess : Hashable {


### PR DESCRIPTION
See commit comment https://github.com/hassila/FlatBuffersSwift/commit/017740e97039d19334b2396b8eb464ec5add321a for details, but the TL;DR, "10% encoding performance by optional manual reuse of builders + added raw access to buffer data when needed".

bench.swift diffs outlines the minor codegen changes needed to support it.
