### PR TITLE
Make reader&builder pools usage thread safe, misc cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: objective-c
 osx_image: xcode7.3
 script:
-  - echo -en "travis_fold:start:generate\r"
-  - sh generate.sh
-  - echo -en "travis_fold:end:generate\r"
+#  - echo -en "travis_fold:start:generate\r"
+#  - sh generate.sh
+#  - echo -en "travis_fold:end:generate\r"
   - echo -en "travis_fold:start:unit_test\r"
   - xcodebuild test -project FlatBuffersSwift.xcodeproj -scheme FlatBuffersSwift ONLY_ACTIVE_ARCH=NO
   - echo -en "travis_fold:end:unit_test\r"

--- a/FlatBuffersPerformanceTestDesktop/bench.swift
+++ b/FlatBuffersPerformanceTestDesktop/bench.swift
@@ -25,7 +25,7 @@ public func ==(v1:Bar, v2:Bar) -> Bool {
 	return  v1.parent==v2.parent &&  v1.time==v2.time &&  v1.ratio==v2.ratio &&  v1.size==v2.size
 }
 public final class FooBar {
-	public static var maxInstanceCacheSize : Int = 0
+	public static var maxInstanceCacheSize : UInt = 0
 	public static var instancePool : [FooBar] = []
 	public var sibling : Bar? = nil
 	public var name : String? {
@@ -177,7 +177,7 @@ public extension FooBar {
 	}
 }
 public final class FooBarContainer {
-	public static var maxInstanceCacheSize : Int = 0
+	public static var maxInstanceCacheSize : UInt = 0
 	public static var instancePool : [FooBarContainer] = []
 	public var list : [FooBar?] = []
 	public var initialized : Bool = false
@@ -282,6 +282,9 @@ public extension FooBarContainer {
 		FlatBufferReader.reuse(reader)
 		return result
 	}
+    public static func fromFlatBufferReader(flatBufferReader : FlatBufferReader) -> FooBarContainer {
+        return create(flatBufferReader, objectOffset : flatBufferReader.rootObjectOffset)!
+    }
 }
 public extension FooBarContainer {
 	public func toByteArray (config : BinaryBuildConfig = BinaryBuildConfig()) -> [UInt8] {

--- a/FlatBuffersSwift/FlatBufferReader.swift
+++ b/FlatBuffersSwift/FlatBufferReader.swift
@@ -13,7 +13,7 @@ public enum FlatBufferReaderError : ErrorType {
 
 public final class FlatBufferReader {
 
-    public static var maxInstanceCacheSize : UInt = 1000 // max number of cached instances
+    public static var maxInstanceCacheSize : UInt = 0 // max number of cached instances
     static var instancePool : [FlatBufferReader] = []
     
     public var config : BinaryReadConfig
@@ -185,7 +185,6 @@ public final class FlatBufferReader {
 }
 
 public extension FlatBufferReader {
-    
     public func reset ()
     {
         buffer = nil
@@ -195,6 +194,9 @@ public extension FlatBufferReader {
     }
     
     public static func create(buffer : [UInt8], config: BinaryReadConfig) -> FlatBufferReader {
+        objc_sync_enter(instancePool)
+        defer { objc_sync_exit(instancePool) }
+
         if (instancePool.count > 0)
         {
             let reader = instancePool.removeLast()
@@ -210,6 +212,9 @@ public extension FlatBufferReader {
     }
     
     public static func create(bytes : UnsafeBufferPointer<UInt8>, config: BinaryReadConfig) -> FlatBufferReader {
+        objc_sync_enter(instancePool)
+        defer { objc_sync_exit(instancePool) }
+
         if (instancePool.count > 0)
         {
             let reader = instancePool.removeLast()
@@ -225,6 +230,9 @@ public extension FlatBufferReader {
     }
     
     public static func create(bytes : UnsafeMutablePointer<UInt8>, count : Int, config: BinaryReadConfig) -> FlatBufferReader {
+        objc_sync_enter(instancePool)
+        defer { objc_sync_exit(instancePool) }
+
         if (instancePool.count > 0)
         {
             let reader = instancePool.removeLast()
@@ -240,6 +248,9 @@ public extension FlatBufferReader {
     }
 
     public static func reuse(reader : FlatBufferReader) {
+        objc_sync_enter(instancePool)
+        defer { objc_sync_exit(instancePool) }
+
         if (UInt(instancePool.count) < maxInstanceCacheSize)
         {
             reader.reset()

--- a/FlatBuffersSwift/FlatBuffers.swift
+++ b/FlatBuffersSwift/FlatBuffers.swift
@@ -43,7 +43,7 @@ extension Float32 : Scalar {}
 extension Float64 : Scalar {}
 
 public protocol PoolableInstances : AnyObject {
-    static var maxInstanceCacheSize : Int { get set }
+    static var maxInstanceCacheSize : UInt { get set }
     static var instancePool : [Self] { get set }
     init()
     func reset()
@@ -52,8 +52,8 @@ public protocol PoolableInstances : AnyObject {
 public extension PoolableInstances {
     
     // Optional preheat of instance pool
-    public static func fillInstancePool(initialPoolSize : Int) -> Void {
-        while ((instancePool.count < initialPoolSize) && (instancePool.count < maxInstanceCacheSize))
+    public static func fillInstancePool(initialPoolSize : UInt) -> Void {
+        while ((UInt(instancePool.count) < initialPoolSize) && (UInt(instancePool.count) < maxInstanceCacheSize))
         {
             instancePool.append(Self())
         }
@@ -72,7 +72,7 @@ public extension PoolableInstances {
     // the final strong reference we hold ourselves to put the instance in for reuse
     public static func reuseInstance(inout instance : Self) {
         
-        if (isUniquelyReferencedNonObjC(&instance) && (instancePool.count < maxInstanceCacheSize))
+        if (isUniquelyReferencedNonObjC(&instance) && (UInt(instancePool.count) < maxInstanceCacheSize))
         {
             instance.reset()
             instancePool.append(instance)

--- a/FlatBuffersSwiftTests/contactList.swift
+++ b/FlatBuffersSwiftTests/contactList.swift
@@ -5,7 +5,7 @@ import Foundation
 
 import FlatBuffersSwift
 public final class ContactList {
-	public static var maxInstanceCacheSize : Int = 0
+	public static var maxInstanceCacheSize : UInt = 0
 	public static var instancePool : [ContactList] = []
 	public var lastModified : Int64 = 0
 	public var entries : [Contact?] = []
@@ -178,7 +178,7 @@ public enum Mood : Int8 {
 	case Funny, Serious, Angry, Humble
 }
 public final class Contact {
-	public static var maxInstanceCacheSize : Int = 0
+    public static var maxInstanceCacheSize : UInt = 0
 	public static var instancePool : [Contact] = []
 	public var name : String? {
 		get {
@@ -498,7 +498,7 @@ public extension Contact {
 	}
 }
 public final class Date {
-	public static var maxInstanceCacheSize : Int = 0
+    public static var maxInstanceCacheSize : UInt = 0
 	public static var instancePool : [Date] = []
 	public var day : Int8 = 0
 	public var month : Int8 = 0
@@ -609,7 +609,7 @@ public func ==(v1:GeoLocation, v2:GeoLocation) -> Bool {
 	return  v1.latitude==v2.latitude &&  v1.longitude==v2.longitude &&  v1.elevation==v2.elevation &&  v1.s==v2.s
 }
 public final class AddressEntry {
-	public static var maxInstanceCacheSize : Int = 0
+    public static var maxInstanceCacheSize : UInt = 0
 	public static var instancePool : [AddressEntry] = []
 	public var order : Int32 = 0
 	public var address : Address? = nil
@@ -697,7 +697,7 @@ public extension AddressEntry {
 	}
 }
 public final class PostalAddress {
-	public static var maxInstanceCacheSize : Int = 0
+    public static var maxInstanceCacheSize : UInt = 0
 	public static var instancePool : [PostalAddress] = []
 	public var country : String? {
 		get {
@@ -910,7 +910,7 @@ public extension PostalAddress {
 	}
 }
 public final class EmailAddress {
-	public static var maxInstanceCacheSize : Int = 0
+    public static var maxInstanceCacheSize : UInt = 0
 	public static var instancePool : [EmailAddress] = []
 	public var mailto : String? {
 		get {
@@ -1025,7 +1025,7 @@ public extension EmailAddress {
 	}
 }
 public final class WebAddress {
-	public static var maxInstanceCacheSize : Int = 0
+    public static var maxInstanceCacheSize : UInt = 0
 	public static var instancePool : [WebAddress] = []
 	public var url : String? {
 		get {
@@ -1140,7 +1140,7 @@ public extension WebAddress {
 	}
 }
 public final class TelephoneNumber {
-	public static var maxInstanceCacheSize : Int = 0
+    public static var maxInstanceCacheSize : UInt = 0
 	public static var instancePool : [TelephoneNumber] = []
 	public var number : String? {
 		get {
@@ -1329,3 +1329,810 @@ private func performLateBindings(builder : FlatBufferBuilder) {
 		}
 	}
 }
+// MARK: Generic Type Definitions
+public typealias Offset = Int32
+
+public protocol Scalar : Equatable {}
+
+extension Scalar {
+    var littleEndian : Self {
+        switch self {
+        case let v as Int16 : return v.littleEndian as! Self
+        case let v as UInt16 : return v.littleEndian as! Self
+        case let v as Int32 : return v.littleEndian as! Self
+        case let v as UInt32 : return v.littleEndian as! Self
+        case let v as Int64 : return v.littleEndian as! Self
+        case let v as UInt64 : return v.littleEndian as! Self
+        case let v as Int : return v.littleEndian as! Self
+        case let v as UInt : return v.littleEndian as! Self
+        default : return self
+        }
+    }
+}
+
+extension Bool : Scalar {}
+extension Int8 : Scalar {}
+extension UInt8 : Scalar {}
+extension Int16 : Scalar {}
+extension UInt16 : Scalar {}
+extension Int32 : Scalar {}
+extension UInt32 : Scalar {}
+extension Int64 : Scalar {}
+extension UInt64 : Scalar {}
+extension Int : Scalar {}
+extension UInt : Scalar {}
+extension Float32 : Scalar {}
+extension Float64 : Scalar {}
+
+public protocol PoolableInstances : AnyObject {
+    static var maxInstanceCacheSize : UInt { get set }
+    static var instancePool : [Self] { get set }
+    init()
+    func reset()
+}
+
+public extension PoolableInstances {
+    
+    // Optional preheat of instance pool
+    public static func fillInstancePool(initialPoolSize : UInt) -> Void {
+        while ((UInt(instancePool.count) < initialPoolSize) && (UInt(instancePool.count) < maxInstanceCacheSize))
+        {
+            instancePool.append(Self())
+        }
+    }
+    
+    public static func createInstance() -> Self {
+        if (instancePool.count > 0)
+        {
+            let instance = instancePool.removeLast()
+            return instance
+        }
+        return Self()
+    }
+    
+    // reuseInstance can be called when we believe we are about to zero out
+    // the final strong reference we hold ourselves to put the instance in for reuse
+    public static func reuseInstance(inout instance : Self) {
+        
+        if (isUniquelyReferencedNonObjC(&instance) && (UInt(instancePool.count) < maxInstanceCacheSize))
+        {
+            instance.reset()
+            instancePool.append(instance)
+        }
+    }
+}
+
+public final class LazyVector<T> : SequenceType {
+    
+    private let _generator : (Int)->T?
+    private let _replacer : ((Int, T)->())?
+    private let _count : Int
+    
+    public init(count : Int, _ generator : (Int)->T?){
+        _generator = generator
+        _count = count
+        _replacer = nil
+    }
+    
+    public init(count : Int, _ generator : (Int)->T?, _ replacer: ((Int, T)->())? = nil){
+        _generator = generator
+        _count = count
+        _replacer = replacer
+    }
+    
+    public subscript(i: Int) -> T? {
+        get {
+            guard i >= 0 && i < _count else {
+                return nil
+            }
+            return _generator(i)
+        }
+        set {
+            guard let replacer = _replacer, let value = newValue else {
+                return
+            }
+            guard i >= 0 && i < _count else {
+                return
+            }
+            replacer(i, value)
+        }
+    }
+    
+    public var count : Int {return _count}
+    
+    public func generate() -> AnyGenerator<T> {
+        var index = 0
+        
+        return AnyGenerator(body: { [self]
+            let value = self[index]
+            index += 1
+            return value
+        })
+    }
+}
+
+public struct BinaryBuildConfig{
+    public let initialCapacity : Int
+    public let uniqueStrings : Bool
+    public let uniqueTables : Bool
+    public let uniqueVTables : Bool
+    public let forceDefaults : Bool
+    public init(initialCapacity : Int = 1, uniqueStrings : Bool = true, uniqueTables : Bool = true, uniqueVTables : Bool = true, forceDefaults : Bool = false) {
+        self.initialCapacity = initialCapacity
+        self.uniqueStrings = uniqueStrings
+        self.uniqueTables = uniqueTables
+        self.uniqueVTables = uniqueVTables
+        self.forceDefaults = forceDefaults
+    }
+}
+
+public struct BinaryReadConfig {
+    public let uniqueTables : Bool
+    public let uniqueStrings : Bool
+    public init(uniqueStrings : Bool = true, uniqueTables : Bool = true) {
+        self.uniqueStrings = uniqueStrings
+        self.uniqueTables = uniqueTables
+    }
+}
+
+// MARK: Reader
+public enum FlatBufferReaderError : ErrorType {
+    case CanOnlySetNonDefaultProperty
+}
+
+public final class FlatBufferReader {
+
+    public static var maxInstanceCacheSize : UInt = 1000 // max number of cached instances
+    static var instancePool : [FlatBufferReader] = []
+    
+    public var config : BinaryReadConfig
+    
+    var buffer : UnsafeMutablePointer<UInt8> = nil
+    public var objectPool : [Offset : AnyObject] = [:]
+    
+    func fromByteArray<T : Scalar>(position : Int) -> T{
+        return UnsafePointer<T>(buffer.advancedBy(position)).memory
+    }
+    
+    private var length : Int
+    public var data : [UInt8] {
+        return Array(UnsafeBufferPointer(start: UnsafePointer<UInt8>(buffer), count: length))
+    }
+
+    public init(buffer : [UInt8], config: BinaryReadConfig){
+        self.buffer = UnsafeMutablePointer<UInt8>(buffer)
+        self.config = config
+        length = buffer.count
+    }
+    
+    public init(bytes : UnsafeBufferPointer<UInt8>, config: BinaryReadConfig){
+        self.buffer = UnsafeMutablePointer<UInt8>(bytes.baseAddress)
+        self.config = config
+        length = bytes.count
+    }
+
+    public init(bytes : UnsafeMutablePointer<UInt8>, count : Int, config: BinaryReadConfig){
+        self.buffer = bytes
+        self.config = config
+        length = count
+    }
+
+    public var rootObjectOffset : Offset {
+        let offset : Int32 = fromByteArray(0)
+        return offset
+    }
+    
+    public func get<T : Scalar>(objectOffset : Offset, propertyIndex : Int, defaultValue : T) -> T{
+        let propertyOffset = getPropertyOffset(objectOffset, propertyIndex: propertyIndex)
+        if propertyOffset == 0 {
+            return defaultValue
+        }
+        let position = Int(objectOffset + propertyOffset)
+        return fromByteArray(position)
+    }
+    
+    public func get<T : Scalar>(objectOffset : Offset, propertyIndex : Int) -> T?{
+        let propertyOffset = getPropertyOffset(objectOffset, propertyIndex: propertyIndex)
+        if propertyOffset == 0 {
+            return nil
+        }
+        let position = Int(objectOffset + propertyOffset)
+        return fromByteArray(position) as T
+    }
+    
+    public func set<T : Scalar>(objectOffset : Offset, propertyIndex : Int, value : T) throws {
+        let propertyOffset = getPropertyOffset(objectOffset, propertyIndex: propertyIndex)
+        if propertyOffset == 0 {
+            throw FlatBufferReaderError.CanOnlySetNonDefaultProperty
+        }
+        var v = value
+        let position = Int(objectOffset + propertyOffset)
+        let c = strideofValue(v)
+        withUnsafePointer(&v){
+            buffer.advancedBy(position).assignFrom(UnsafeMutablePointer<UInt8>($0), count: c)
+        }
+    }
+    
+    public func hasProperty(objectOffset : Offset, propertyIndex : Int) -> Bool {
+        return getPropertyOffset(objectOffset, propertyIndex: propertyIndex) != 0
+    }
+    
+    public func getOffset(objectOffset : Offset, propertyIndex : Int) -> Offset?{
+        let propertyOffset = getPropertyOffset(objectOffset, propertyIndex: propertyIndex)
+        if propertyOffset == 0 {
+            return nil
+        }
+        let position = objectOffset + propertyOffset
+        let localObjectOffset : Int32 = fromByteArray(Int(position))
+        let offset = position + localObjectOffset
+        
+        if localObjectOffset == 0 {
+            return nil
+        }
+        return offset
+    }
+    
+    var stringCache : [Int32:String] = [:]
+    
+    public func getString(stringOffset : Offset?) -> String? {
+        guard let stringOffset = stringOffset else {
+            return nil
+        }
+        if config.uniqueStrings {
+            if let result = stringCache[stringOffset]{
+                return result
+            }
+        }
+        
+        let stringPosition = Int(stringOffset)
+        let stringLength : Int32 = fromByteArray(stringPosition)
+        
+        let pointer = UnsafeMutablePointer<UInt8>(buffer).advancedBy((stringPosition + strideof(Int32)))
+        let result = String.init(bytesNoCopy: pointer, length: Int(stringLength), encoding: NSUTF8StringEncoding, freeWhenDone: false)
+        
+        if config.uniqueStrings {
+            stringCache[stringOffset] = result
+        }
+        return result
+    }
+    
+    public func getStringBuffer(stringOffset : Offset?) -> UnsafeBufferPointer<UInt8>? {
+        guard let stringOffset = stringOffset else {
+            return nil
+        }
+        let stringPosition = Int(stringOffset)
+        let stringLength : Int32 = fromByteArray(stringPosition)
+        let pointer = UnsafePointer<UInt8>(buffer).advancedBy((stringPosition + strideof(Int32)))
+        return UnsafeBufferPointer<UInt8>.init(start: pointer, count: Int(stringLength))
+    }
+    
+    public func getVectorLength(vectorOffset : Offset?) -> Int {
+        guard let vectorOffset = vectorOffset else {
+            return 0
+        }
+        let vectorPosition = Int(vectorOffset)
+        let length2 : Int32 = fromByteArray(vectorPosition)
+        return Int(length2)
+    }
+    
+    public func getVectorScalarElement<T : Scalar>(vectorOffset : Offset, index : Int) -> T {
+        let valueStartPosition = Int(vectorOffset + strideof(Int32) + (index * strideof(T)))
+        return UnsafePointer<T>(UnsafePointer<UInt8>(buffer).advancedBy(valueStartPosition)).memory
+    }
+    
+    public func setVectorScalarElement<T : Scalar>(vectorOffset : Offset, index : Int, value : T) {
+        let valueStartPosition = Int(vectorOffset + strideof(Int32) + (index * strideof(T)))
+        var v = value
+        let c = strideofValue(v)
+        withUnsafePointer(&v){
+            buffer.advancedBy(valueStartPosition).assignFrom(UnsafeMutablePointer<UInt8>($0), count: c)
+        }
+    }
+    
+    public func getVectorOffsetElement(vectorOffset : Offset, index : Int) -> Offset? {
+        let valueStartPosition = Int(vectorOffset + strideof(Int32) + (index * strideof(Int32)))
+        let localOffset : Int32 = fromByteArray(valueStartPosition)
+        if(localOffset == 0){
+            return nil
+        }
+        return localOffset + valueStartPosition
+    }
+    
+    private func getPropertyOffset(objectOffset : Offset, propertyIndex : Int)->Int {
+        let offset = Int(objectOffset)
+        let localOffset : Int32 = fromByteArray(offset)
+        let vTableOffset : Int = offset - Int(localOffset)
+        let vTableLength : Int16 = fromByteArray(vTableOffset)
+        if(vTableLength<=Int16(4 + propertyIndex * 2)) {
+            return 0
+        }
+        let propertyStart = vTableOffset + 4 + (2 * propertyIndex)
+        
+        let propertyOffset : Int16 = fromByteArray(propertyStart)
+        return Int(propertyOffset)
+    }
+}
+
+public extension FlatBufferReader {
+    
+    public func reset ()
+    {
+        buffer = nil
+        objectPool.removeAll(keepCapacity: true)
+        stringCache.removeAll(keepCapacity: true)
+        length = 0
+    }
+    
+    public static func create(buffer : [UInt8], config: BinaryReadConfig) -> FlatBufferReader {
+        objc_sync_enter(instancePool)
+        defer { objc_sync_exit(instancePool) }
+
+        if (instancePool.count > 0)
+        {
+            let reader = instancePool.removeLast()
+            
+            reader.buffer = UnsafeMutablePointer<UInt8>(buffer)
+            reader.config = config
+            reader.length = buffer.count
+            
+            return reader
+        }
+        
+        return FlatBufferReader(buffer: buffer, config: config)
+    }
+    
+    public static func create(bytes : UnsafeBufferPointer<UInt8>, config: BinaryReadConfig) -> FlatBufferReader {
+        objc_sync_enter(instancePool)
+        defer { objc_sync_exit(instancePool) }
+
+        if (instancePool.count > 0)
+        {
+            let reader = instancePool.removeLast()
+            
+            reader.buffer = UnsafeMutablePointer(bytes.baseAddress)
+            reader.config = config
+            reader.length = bytes.count
+            
+            return reader
+        }
+        
+        return FlatBufferReader(bytes: bytes, config: config)
+    }
+    
+    public static func create(bytes : UnsafeMutablePointer<UInt8>, count : Int, config: BinaryReadConfig) -> FlatBufferReader {
+        objc_sync_enter(instancePool)
+        defer { objc_sync_exit(instancePool) }
+
+        if (instancePool.count > 0)
+        {
+            let reader = instancePool.removeLast()
+            
+            reader.buffer = bytes
+            reader.config = config
+            reader.length = count
+            
+            return reader
+        }
+        
+        return FlatBufferReader(bytes: bytes, count: count, config: config)
+    }
+
+    public static func reuse(reader : FlatBufferReader) {
+        objc_sync_enter(instancePool)
+        defer { objc_sync_exit(instancePool) }
+
+        if (UInt(instancePool.count) < maxInstanceCacheSize)
+        {
+            reader.reset()
+            instancePool.append(reader)
+        }
+    }
+}
+// MARK: Builder
+public enum FlatBufferBuilderError : ErrorType {
+    case ObjectIsNotClosed
+    case NoOpenObject
+    case PropertyIndexIsInvalid
+    case OffsetIsTooBig
+    case CursorIsInvalid
+    case BadFileIdentifier
+    case UnsupportedType
+}
+
+public final class FlatBufferBuilder {
+    
+    public static var maxInstanceCacheSize : UInt = 1000 // max number of cached instances
+    static var instancePool : [FlatBufferBuilder] = []
+    
+    public var cache : [ObjectIdentifier : Offset] = [:]
+    public var inProgress : Set<ObjectIdentifier> = []
+    public var deferedBindings : [(object:Any, cursor:Int)] = []
+    
+    public var config : BinaryBuildConfig
+    
+    var capacity : Int
+    private var _data : UnsafeMutablePointer<UInt8>
+    public var _dataCount : Int { return cursor } // count of bytes in unsafe buffer
+    public var _dataStart : UnsafeMutablePointer<UInt8> { return _data.advancedBy(leftCursor) } // start of actual raw unsafe buffer data
+    public var data : [UInt8] {
+        return Array(UnsafeBufferPointer(start: UnsafePointer<UInt8>(_data).advancedBy(leftCursor), count: cursor))
+    }
+    var cursor = 0
+    var leftCursor : Int {
+        return capacity - cursor
+    }
+    
+    var currentVTable : [Int32] = []
+    var objectStart : Int32 = -1
+    var vectorNumElems : Int32 = -1;
+    var vTableOffsets : [Int32] = []
+    
+    public init(config : BinaryBuildConfig){
+        self.config = config
+        self.capacity = config.initialCapacity
+        _data = UnsafeMutablePointer.alloc(capacity)
+    }
+    
+    deinit {
+        _data.dealloc(capacity)
+    }    
+
+    private func increaseCapacity(size : Int){
+        guard leftCursor <= size else {
+            return
+        }
+        let _leftCursor = leftCursor
+        let _capacity = capacity
+        while leftCursor <= size {
+            capacity = capacity << 1
+        }
+        
+        let newData = UnsafeMutablePointer<UInt8>.alloc(capacity)
+        newData.advancedBy(leftCursor).initializeFrom(_data.advancedBy(_leftCursor), count: cursor)
+        _data.dealloc(_capacity)
+        _data = newData
+    }
+    
+    public func put<T : Scalar>(value : T){
+        var v = value
+        if UInt32(CFByteOrderGetCurrent()) == CFByteOrderBigEndian.rawValue{
+            v = value.littleEndian
+        }
+        let c = strideofValue(v)
+        increaseCapacity(c)
+        withUnsafePointer(&v){
+            _data.advancedBy(leftCursor-c).assignFrom(UnsafeMutablePointer<UInt8>($0), count: c)
+        }
+        cursor += c
+
+    }
+    
+    public func put<T : Scalar>(value : UnsafePointer<T>, length : Int){
+        increaseCapacity(length)
+        _data.advancedBy(leftCursor-length).assignFrom(UnsafeMutablePointer<UInt8>(value), count: length)
+        cursor += length
+    }
+    
+    public func putOffset(offset : Offset?) throws -> Int { // make offset relative and put it into byte buffer
+        guard let offset = offset else {
+            put(Offset(0))
+            return cursor
+        }
+        guard offset <= Int32(cursor) else {
+            throw FlatBufferBuilderError.OffsetIsTooBig
+        }
+        
+        if offset == Int32(0) {
+            put(Offset(0))
+            return cursor
+        }
+        let _offset = Int32(cursor) - offset + strideof(Int32);
+        put(_offset)
+        return cursor
+    }
+    
+    public func replaceOffset(offset : Offset, atCursor jumpCursor: Int) throws{
+        guard offset <= Int32(cursor) else {
+            throw FlatBufferBuilderError.OffsetIsTooBig
+        }
+        guard jumpCursor <= cursor else {
+            throw FlatBufferBuilderError.CursorIsInvalid
+        }
+        let _offset = Int32(jumpCursor) - offset;
+        
+        var v = _offset
+        if UInt32(CFByteOrderGetCurrent()) == CFByteOrderBigEndian.rawValue{
+            v = _offset.littleEndian
+        }
+        let c = strideofValue(v)
+        withUnsafePointer(&v){
+            _data.advancedBy((capacity - jumpCursor)).assignFrom(UnsafeMutablePointer<UInt8>($0), count: c)
+        }
+    }
+    
+    private func put<T : Scalar>(value : T, at index : Int){
+        var v = value
+        if UInt32(CFByteOrderGetCurrent()) == CFByteOrderBigEndian.rawValue{
+            v = value.littleEndian
+        }
+        let c = strideofValue(v)
+        withUnsafePointer(&v){
+            _data.advancedBy(index + leftCursor).assignFrom(UnsafeMutablePointer<UInt8>($0), count: c)
+        }
+    }
+    
+    public func openObject(numOfProperties : Int) throws {
+        guard objectStart == -1 && vectorNumElems == -1 else {
+            throw FlatBufferBuilderError.ObjectIsNotClosed
+        }
+        currentVTable.removeAll(keepCapacity: true)
+        currentVTable.reserveCapacity(numOfProperties)
+        for _ in 0..<numOfProperties {
+            currentVTable.append(0)
+        }
+        objectStart = Int32(cursor)
+    }
+    
+    public func addPropertyOffsetToOpenObject(propertyIndex : Int, offset : Offset) throws -> Int{
+        guard objectStart > -1 else {
+            throw FlatBufferBuilderError.NoOpenObject
+        }
+        guard propertyIndex >= 0 && propertyIndex < currentVTable.count else {
+            throw FlatBufferBuilderError.PropertyIndexIsInvalid
+        }
+        try putOffset(offset)
+        currentVTable[propertyIndex] = Int32(cursor)
+        return cursor
+    }
+    
+    public func addPropertyToOpenObject<T : Scalar>(propertyIndex : Int, value : T, defaultValue : T) throws {
+        guard objectStart > -1 else {
+            throw FlatBufferBuilderError.NoOpenObject
+        }
+        guard propertyIndex >= 0 && propertyIndex < currentVTable.count else {
+            throw FlatBufferBuilderError.PropertyIndexIsInvalid
+        }
+        
+        if(config.forceDefaults == false && value == defaultValue) {
+            return
+        }
+        
+        put(value)
+        currentVTable[propertyIndex] = Int32(cursor)
+    }
+    
+    public func addCurrentOffsetAsPropertyToOpenObject(propertyIndex : Int) throws {
+        guard objectStart > -1 else {
+            throw FlatBufferBuilderError.NoOpenObject
+        }
+        guard propertyIndex >= 0 && propertyIndex < currentVTable.count else {
+            throw FlatBufferBuilderError.PropertyIndexIsInvalid
+        }
+        currentVTable[propertyIndex] = Int32(cursor)
+    }
+    
+    public func closeObject() throws -> Offset {
+        guard objectStart > -1 else {
+            throw FlatBufferBuilderError.NoOpenObject
+        }
+        
+        increaseCapacity(4)
+        cursor += 4 // Will be set to vtable offset afterwards
+        
+        let vtableloc = cursor
+        
+        // vtable is stored as relative offset for object data
+        var index = currentVTable.count - 1
+        while(index>=0) {
+            // Offset relative to the start of the table.
+            let off = Int16(currentVTable[index] != 0 ? Int32(vtableloc) - currentVTable[index] : 0);
+            put(off);
+            index -= 1
+        }
+        
+        let numberOfstandardFields = 2
+        
+        put(Int16(Int32(vtableloc) - objectStart)); // standard field 1: lenght of the object data
+        put(Int16((currentVTable.count + numberOfstandardFields) * strideof(Int16))); // standard field 2: length of vtable and standard fields them selves
+        
+        // search if we already have same vtable
+        let vtableDataLength = cursor - vtableloc
+        
+        var foundVTableOffset = vtableDataLength
+        
+        if config.uniqueVTables{
+            for otherVTableOffset in vTableOffsets {
+                let start = cursor - Int(otherVTableOffset)
+                var found = true
+                for i in 0 ..< vtableDataLength {
+                    let a = _data.advancedBy(leftCursor + i).memory
+                    let b = _data.advancedBy(leftCursor + i + start).memory
+                    if a != b {
+                        found = false
+                        break;
+                    }
+                }
+                if found == true {
+                    foundVTableOffset = Int(otherVTableOffset) - vtableloc
+                    break
+                }
+            }
+            
+            if foundVTableOffset != vtableDataLength {
+                cursor -= vtableDataLength
+            } else {
+                vTableOffsets.append(Int32(cursor))
+            }
+        }
+        
+        let indexLocation = cursor - vtableloc
+        
+        put(Int32(foundVTableOffset), at: indexLocation)
+        
+        objectStart = -1
+        
+        return Offset(vtableloc)
+    }
+    
+    public func startVector(count : Int) throws{
+        guard objectStart == -1 && vectorNumElems == -1 else {
+            throw FlatBufferBuilderError.ObjectIsNotClosed
+        }
+        vectorNumElems = Int32(count)
+    }
+    
+    public func endVector() -> Offset {
+        put(vectorNumElems)
+        vectorNumElems = -1
+        return Int32(cursor)
+    }
+    
+    private var stringCache : [String:Offset] = [:]
+    public func createString(value : String?) throws -> Offset {
+        guard objectStart == -1 && vectorNumElems == -1 else {
+            throw FlatBufferBuilderError.ObjectIsNotClosed
+        }
+        guard let value = value else {
+            return 0
+        }
+        
+        if config.uniqueStrings{
+            if let o = stringCache[value]{
+                return o
+            }
+        }
+
+        let length = value.utf8.count
+        
+        increaseCapacity(length)
+        
+        let p = UnsafeMutablePointer<UInt8>(_data.advancedBy(leftCursor-length))
+        var charofs = 0
+        for c in value.utf8
+        {
+            assert(charofs < length)
+            p.advancedBy(charofs).memory = c
+            charofs = charofs + 1
+        }
+        
+        cursor += length
+
+        put(Int32(length))
+        
+        let o = Offset(cursor)
+        if config.uniqueStrings {
+            stringCache[value] = o
+        }
+        return o
+    }
+    
+    public func createString(value : UnsafeBufferPointer<UInt8>?) throws -> Offset {
+        guard objectStart == -1 && vectorNumElems == -1 else {
+            throw FlatBufferBuilderError.ObjectIsNotClosed
+        }
+        guard let value = value else {
+            return 0
+        }
+        let length = value.count
+        increaseCapacity(length)
+        _data.advancedBy(leftCursor-length).assignFrom(UnsafeMutablePointer(value.baseAddress), count: length)
+        cursor += length
+        put(Int32(length))
+        return Offset(cursor)
+    }
+    
+    public func createStaticString(value : StaticString?) throws -> Offset {
+        guard objectStart == -1 && vectorNumElems == -1 else {
+            throw FlatBufferBuilderError.ObjectIsNotClosed
+        }
+        guard let value = value else {
+            return 0
+        }
+        
+        let buf = value.utf8Start
+        let length = value.byteSize
+        
+        increaseCapacity(length)
+        _data.advancedBy(leftCursor-length).assignFrom(UnsafeMutablePointer<UInt8>(buf), count: length)
+        cursor += length
+        
+        put(Int32(length))
+        return Offset(cursor)
+    }
+    
+    public func finish(offset : Offset, fileIdentifier : String?) throws -> Void {
+        guard offset <= Int32(cursor) else {
+            throw FlatBufferBuilderError.OffsetIsTooBig
+        }
+        guard objectStart == -1 && vectorNumElems == -1 else {
+            throw FlatBufferBuilderError.ObjectIsNotClosed
+        }
+        var prefixLength = 4
+        increaseCapacity(8)
+        if let fileIdentifier = fileIdentifier {
+            let buf = fileIdentifier.utf8
+            guard buf.count == 4 else {
+                throw FlatBufferBuilderError.BadFileIdentifier
+            }
+            
+            _data.advancedBy(leftCursor-4).initializeFrom(buf)
+            prefixLength += 4
+        }
+        
+        var v = (Int32(cursor + prefixLength) - offset).littleEndian
+        let c = strideofValue(v)
+        withUnsafePointer(&v){
+            _data.advancedBy(leftCursor - prefixLength).assignFrom(UnsafeMutablePointer<UInt8>($0), count: c)
+        }
+        cursor += prefixLength
+    }
+}
+
+// Pooling
+public extension FlatBufferBuilder {
+    
+    public func reset ()
+    {
+        cursor = 0
+        objectStart = -1
+        vectorNumElems = -1;
+        vTableOffsets.removeAll(keepCapacity: true)
+        currentVTable.removeAll(keepCapacity: true)
+        cache.removeAll(keepCapacity: true)
+        inProgress.removeAll(keepCapacity: true)
+        deferedBindings.removeAll(keepCapacity: true)
+        stringCache.removeAll(keepCapacity: true)
+    }
+    
+    public static func create(config: BinaryBuildConfig) -> FlatBufferBuilder {
+        objc_sync_enter(instancePool)
+        defer { objc_sync_exit(instancePool) }
+
+        if (instancePool.count > 0)
+        {
+            let builder = instancePool.removeLast()
+            builder.config = config
+            if (config.initialCapacity > builder.capacity) {
+                builder._data.dealloc(builder.capacity)
+                builder.capacity = config.initialCapacity
+                builder._data = UnsafeMutablePointer.alloc(builder.capacity)
+            }
+            return builder
+        }
+        
+        return FlatBufferBuilder(config: config)
+    }
+    
+    public static func reuse(builder : FlatBufferBuilder) {
+        objc_sync_enter(instancePool)
+        defer { objc_sync_exit(instancePool) }
+
+        if (UInt(instancePool.count) < maxInstanceCacheSize)
+        {
+            builder.reset()
+            instancePool.append(builder)
+        }
+    }
+    
+}
+


### PR DESCRIPTION
See https://github.com/mzaks/FlatBuffersSwift/commit/145624ab0d245168110e16fd5cfe6fbeaa144088 for details.

```
Eager run before:
=================================
1581 ms encode
325 ms decode
40 ms use
211 ms dealloc
576 ms decode+use+dealloc
=================================

After:
Eager run
=================================
1527 ms encode
261 ms decode
32 ms use
205 ms dealloc
498 ms decode+use+dealloc
=================================

```

(using the new reusable reader API)

Partly addresses https://github.com/mzaks/FlatBuffersSwift/issues/44
