### PR TITLE
Clean up of benchmark to get comparable numbers for struct/direct runs

### DIFF
--- a/FlatBuffersPerformanceTestDesktop/flatbench.swift
+++ b/FlatBuffersPerformanceTestDesktop/flatbench.swift
@@ -297,6 +297,7 @@ func runbench(runType: BenchmarkRunType) -> (Int, Int)
 
         let time6 = CFAbsoluteTimeGetCurrent()
 
+        // Clean up
         let time7 = CFAbsoluteTimeGetCurrent()
         
         switch runType {
@@ -337,12 +338,11 @@ func runbench(runType: BenchmarkRunType) -> (Int, Int)
 }
 
 func flatbench() {
-    
     let benchMarks : [BenchmarkRunType] = [.lazyDecode, .eagerDecode, .directDecode, .structDecode]
-
     var total = 0
     var subtotal = 0
     var messageSize = 0
+    
     print("Running a total of \(inner_loop_iterations*iterations) iterations")
     print("")
     


### PR DESCRIPTION
Will probably clean out lazy/direct for the final cut, but now we can compare all four in a reasonable way.
